### PR TITLE
Flatten tags to make sure a normal cache call will work.

### DIFF
--- a/lib/cashier.rb
+++ b/lib/cashier.rb
@@ -26,7 +26,7 @@ module Cashier
   #
   def store_fragment(fragment, *tags)
     return unless perform_caching?
-
+    tags = tags.flatten
     ActiveSupport::Notifications.instrument("store_fragment.cashier", :data => [fragment, tags]) do
       tags.each do |tag|
         # store the fragment


### PR DESCRIPTION
I found that when I tried to cache using the below example, it was not flattening the tags, hence the final cache key used to link the tag with the fragment was "parent/aunty" instead of having 2 separate cache entries. So then the gem never expired the fragment properly.
- cache("key", :tags=>["parent", "aunty"]) do 
    = something_that_cache
