### PR TITLE
Cashier.expire should clear keys stored in that tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Rails.cache.write("foo", "bar", :tag => ["some_tag"])
 # what's cached
 Cashier.tags
 
-# sweep all stored keys
+# Clears out all tagged keys and tags
 Cashier.clear
 ```
 
@@ -157,10 +157,16 @@ ActiveSupport::Notifications.subscribe("store_fragment.cashier") do |name, start
 		
 end
 
+# Subscribe to the expire event.
+# payload[:data] will be the list of tags expired.
+ActiveSupport::Notifications.subscribe("expire.cashier") do |name, start, finish, id, payload|
+    
+end 
+
 # Subscribe to the clear event. (no data)
 ActiveSupport::Notifications.subscribe("clear.cashier") do |name, start, finish, id, payload|
-		
-end	
+    
+end 
 
 # Subscribe to the delete_cache_key event
 # this event will fire every time there's a Rails.cache.delete with the key

--- a/lib/cashier.rb
+++ b/lib/cashier.rb
@@ -56,6 +56,7 @@ module Cashier
         tags.each do |tag|
           fragment_keys = adapter.get_fragments_for_tag(tag)
 
+          # Delete each fragment from the cache.
           fragment_keys.each do |fragment_key|
             Rails.cache.delete(fragment_key)
           end
@@ -90,6 +91,17 @@ module Cashier
     #
     def clear
       ActiveSupport::Notifications.instrument("clear.cashier") do
+        # delete them from the cache
+        tags.each do |tag|
+          fragment_keys = adapter.get_fragments_for_tag(tag)
+          # Delete each fragment from the cache.
+          fragment_keys.each do |fragment_key|
+            Rails.cache.delete(fragment_key)
+          end
+          # Delete the tag itself
+          adapter.delete_tag(tag)
+        end
+
         adapter.clear
       end
     end
@@ -118,7 +130,8 @@ module Cashier
       adapter.get_fragments_for_tag(tag)
     end
 
-    # Public: adapter which is used by cashier.
+    # Public: adapter which is used by cashier. 
+    # Defaults to :cache_store
     #
     # Examples
     #

--- a/lib/cashier.rb
+++ b/lib/cashier.rb
@@ -103,6 +103,7 @@ module Cashier
         end
 
         adapter.clear
+        tags.count
       end
     end
 

--- a/lib/cashier.rb
+++ b/lib/cashier.rb
@@ -129,6 +129,7 @@ module Cashier
     #   # => Cashier::Adapters::RedisStore
     #
     def adapter
+      @@adapter ||= :cache_store
       if @@adapter == :cache_store
         Cashier::Adapters::CacheStore
       else


### PR DESCRIPTION
As it currently seems to be working, if I expire a tag using cashier, after expiring all the keys associated with the tag, those keys still exist in that tag's list of keys. (I'm using Redis)

For example:

I am action caching a search page tagged with "locations" where the search string is part of the cache key. So the following would be a list of the cache keys created over a period of time:

```
views/localhost:3000/locations?q=1
views/localhost:3000/locations?q=2
views/localhost:3000/locations?q=3
```

Those three keys would be in the list under the key based on the tag "locations".

If I run `Cashier.expire "locations"`, those three view caches are correctly expired. However, if I then visit `views/localhost:3000/locations?q=4`, and then run `Cashier.keys`, I get the following output:

```
views/localhost:3000/locations?q=1
views/localhost:3000/locations?q=2
views/localhost:3000/locations?q=3
views/localhost:3000/locations?q=4
```

This is because when the tag was expired, the "locations" entry in Redis was left as is.

Is this intended? My opinion is that any key expired should be removed from the tag's list of keys. In a production environment, if there is an infinite number of queries my users would search for, then the "locations" tag's list of keys would grow infinitely as well, and it doesn't seem reasonable to expire the tag myself after running the expire method, as this is a jump into the inner workings of Cashier that my app shouldn't expect to understand.
