### PR TITLE
Remove cache instrumentation config

### DIFF
--- a/lib/cashier/railtie.rb
+++ b/lib/cashier/railtie.rb
@@ -1,9 +1,5 @@
 module Cashier
   class Railtie < ::Rails::Railtie
     config.cashier = Cashier
-
-    initializer "cashier.active_support.cache.instrumentation" do |app|
-      ActiveSupport::Cache::Store.instrument = true
-    end
   end
 end


### PR DESCRIPTION
Depreciated in Rails 4.2.1.